### PR TITLE
ObjectifyByGroup: use full name qualify to reference core component

### DIFF
--- a/graphs/ObjectifyByGroup.fbp
+++ b/graphs/ObjectifyByGroup.fbp
@@ -2,5 +2,5 @@ EXPORT=OBJECTIFY.IN:IN
 EXPORT=REMOVE.OUT:OUT
 EXPORT=REGEXP.IN:REGEXP
 
-Regexp(Split) OUT -> REGEXP Objectify(groups/Objectify) OUT -> IN Remove(groups/RemoveGroups)
+Regexp(core/Split) OUT -> REGEXP Objectify(groups/Objectify) OUT -> IN Remove(groups/RemoveGroups)
 Regexp() OUT -> REGEXP Remove()


### PR DESCRIPTION
Better be precise about which Split component the graph wants to use.
